### PR TITLE
Add HTTP 500 to list of responses which indicate web console is not yet ready

### DIFF
--- a/workstation.yml
+++ b/workstation.yml
@@ -36,7 +36,7 @@
         webconsole_uri.status >= 500
       retries: 60
       delay: 10
-      # 404 and 503 are the statuses that are seen when the Zenith service is not ready yet
+      # 404, 500 and 503 are the statuses that are seen when the Zenith service is not ready yet
       # An SSL error is indicated as -1, which will occur while cert-manager fetches certificates
-      until: webconsole_uri.status not in [404, 503, -1]
+      until: webconsole_uri.status not in [404, 500, 503, -1]
       when: (cluster_state | default('present')) == 'present'


### PR DESCRIPTION
We occasionally see cases where Nginx returns a HTTP 500 error code instead (of the previously documented 404 or 503) if ansible polls the service readiness somewhere between the time where the ingress resource is registered and the time when the backend is ready to response. In these cases we see Nginx logs such as
```
192.168.3.32 - - [16/Nov/2023:16:11:23 +0000] "GET /realms/az-rcp-cloud-portal-demo/.well-known/openid-configuration HTTP/1.1" 200 6714 "-" "Go-http-client/1.1" 183 0.004 [keycloak-system-keycloak-service-8080] [] 172.19.214.223:8080 6714 0.004 200 b4cc0a30338a583be988894558e7ff82
2023/11/16 16:11:24 [error] 6676#6676: *343015 connect() failed (111: Connection refused) while connecting to upstream, client: 192.168.3.32, server: uvwy1n5nev8ah9u2cm9knckpp8hkq2se3w.apps.128-232-226-102.sslip.io, request: "GET / HTTP/1.1", subrequest: "/_external-auth-Lw-Prefix", upstream: "http://172.29.123.64:80/_oidc/auth", host: "uvwy1n5nev8ah9u2cm9knckpp8hkq2se3w.apps.128-232-226-102.sslip.io"
2023/11/16 16:11:24 [error] 6676#6676: *343015 auth request unexpected status: 502 while sending to client, client: 192.168.3.32, server: uvwy1n5nev8ah9u2cm9knckpp8hkq2se3w.apps.128-232-226-102.sslip.io, request: "GET / HTTP/1.1", host: "uvwy1n5nev8ah9u2cm9knckpp8hkq2se3w.apps.128-232-226-102.sslip.io"
192.168.3.32 - - [16/Nov/2023:16:11:24 +0000] "GET / HTTP/1.1" 500 170 "-" "ansible-httpget" 165 0.001 [zenith-services-uvwy1n5nev8ah9u2cm9knckpp8hkq2se3w-dynamic] [] - - - - 02e4eb6f5498ba6947d4e1b3e0ba4e65
```
i.e. nginx gets a 502 from the service and so responds with a 500 to ansible. This causes the ansible create job to fail with
```
restore-test-1-create-vbmjz-nvvds run {"uuid": "7e3a8c87-ce34-4d04-9b13-140549d9df0d", "counter": 51, "stdout": "fatal: [localhost]: FAILED! => {\"attempts\": 2, \"changed\": false, \"connection\": \"close\", \"content_length\": \"170\", \"content_type\": \"text/html\", \"date\": \"Thu, 16 Nov 2023 16:1
1:24 GMT\", \"elapsed\": 0, \"failed_when_result\": true, \"msg\": \"Status code was 500 and not [200]: HTTP Error 500: Internal Server Error\", \"redirected\": false, \"status\": 500, \"url\": \"http://uvwy1n5nev8ah9u2cm9knckpp8hkq2se3w.apps.128-232-226-102.sslip.io\"}", "start_line": 48, "end_line": 4
9, "runner_ident": "9f7097bb-7f46-44f7-9f3f-7aa5046bc379", "event": "runner_on_failed", "pid": 39, "created": "2023-11-16T16:11:24.342784", "parent_uuid": "ca2b1570-4e2d-1a1a-94b7-000000000015", "event_data": {"playbook": "workstation.yml", "playbook_uuid": "e6ffbd38-1eff-4869-8d30-04906e27b4bd", "play"
: "Provision infrastructure", "play_uuid": "ca2b1570-4e2d-1a1a-94b7-000000000002", "play_pattern": "openstack", "task": "Wait for webconsole to become available", "task_uuid": "ca2b1570-4e2d-1a1a-94b7-000000000015", "task_action": "uri", "resolved_action": "ansible.builtin.uri", "task_args": "", "task_p
ath": "/runner/project/workstation.yml:26", "host": "localhost", "remote_addr": "localhost", "res": {"redirected": false, "url": "http://uvwy1n5nev8ah9u2cm9knckpp8hkq2se3w.apps.128-232-226-102.sslip.io", "status": 500, "date": "Thu, 16 Nov 2023 16:11:24 GMT", "content_type": "text/html", "content_length
": "170", "connection": "close", "elapsed": 0, "changed": false, "msg": "Status code was 500 and not [200]: HTTP Error 500: Internal Server Error", "invocation": {"module_args": {"url": "http://uvwy1n5nev8ah9u2cm9knckpp8hkq2se3w.apps.128-232-226-102.sslip.io", "method": "GET", "follow_redirects": "safe"
, "force": false, "http_agent": "ansible-httpget", "use_proxy": true, "validate_certs": true, "force_basic_auth": false, "use_gssapi": false, "body_format": "raw", "return_content": false, "status_code": [200], "timeout": 30, "headers": {}, "remote_src": false, "unredirected_headers": [], "decompress": 
true, "use_netrc": true, "unsafe_writes": false, "url_username": null, "url_password": null, "client_cert": null, "client_key": null, "dest": null, "body": null, "src": null, "creates": null, "removes": null, "unix_socket": null, "ca_path": null, "ciphers": null, "mode": null, "owner": null, "group": nu
ll, "seuser": null, "serole": null, "selevel": null, "setype": null, "attributes": null}}, "_ansible_no_log": null, "attempts": 2, "failed_when_result": true}, "start": "2023-11-16T16:11:13.222412", "end": "2023-11-16T16:11:24.342678", "duration": 11.120266, "ignore_errors": null, "event_loop": null, "u
uid": "7e3a8c87-ce34-4d04-9b13-140549d9df0d"}}
```

Allowing ansible to retry on 500 errors seems like the simplest fix to me.