### PR TITLE
Use project manila share user from Azimuth

### DIFF
--- a/workstation.yml
+++ b/workstation.yml
@@ -60,7 +60,7 @@
   vars:
     os_manila_mount_shares:
       - share_name: azimuth-project-share
-        share_user: "{{ cluster_project_manila_share_user }}"
+        share_user: "{{ cluster_project_manila_share_user | default(omit) }}"
         mount_path: /project
         mount_user: root
         mount_group: root

--- a/workstation.yml
+++ b/workstation.yml
@@ -59,7 +59,7 @@
   become: yes
   vars:
     os_manila_mount_shares:
-      - share_name: azimuth-project-share
+      - share_name: "{{ cluster_project_manila_share_name | default('azimuth-project-share') }}"
         share_user: "{{ cluster_project_manila_share_user | default(omit) }}"
         mount_path: /project
         mount_user: root

--- a/workstation.yml
+++ b/workstation.yml
@@ -60,6 +60,7 @@
   vars:
     os_manila_mount_shares:
       - share_name: azimuth-project-share
+        share_user: "{{ cluster_project_manila_share_user }}"
         mount_path: /project
         mount_user: root
         mount_group: root


### PR DESCRIPTION
Changes project manila shares to use the share user provided by Azimuth (in https://github.com/stackhpc/azimuth/pull/148/files), rather assuming there is only a single access rule. Fixes cases where multiple access rules are defined on the project share.