### PR TITLE
Use OpenTofu instead of Terraform for CaaS

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@
 collections:
   - name: https://github.com/stackhpc/ansible-collection-terraform
     type: git
-    version: c07b6cf85eb5e50441e4be9ff50fca85f08e8a00
+    version: 0.2.0
   - name: openstack.cloud
     version: 1.8.0
   - name: ansible.posix # for mount module

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,5 +1,0 @@
----
-collections:
-  - name: https://github.com/stackhpc/ansible-collection-terraform
-    type: git
-    version: 8c7acce4538aab8c0e928972155a2ccb5cb1b2a1


### PR DESCRIPTION
Bumps terraform collection to get opentofu. Note there were two requirements.yml files - from the [caas operator logic](https://github.com/stackhpc/azimuth-caas-operator/blob/main/azimuth_caas_operator/utils/ansible_runner.py#L221) the preferred one is in the root of the project.