### PR TITLE
Bump os-manila-mount role to default to Quincy

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -11,4 +11,4 @@ collections:
 roles:
   - src: https://github.com/stackhpc/ansible-role-os-manila-mount.git
     name: stackhpc.os-manila-mount
-    version: v24.1.1
+    version: v24.5.0


### PR DESCRIPTION
See https://github.com/stackhpc/ansible-role-os-manila-mount/pull/9