### PR TITLE
Move to openstack_networking_floatingip_associate_v2

### DIFF
--- a/roles/cluster_infra/templates/providers.tf.j2
+++ b/roles/cluster_infra/templates/providers.tf.j2
@@ -5,6 +5,10 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      # TODO we must upgraded to 3.0.0
+      # but only after we stop using the deprecated
+      # openstack_compute_floatingip_associate_v2
+      version = "~>2.1.0"
     }
   }
 }

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -185,8 +185,8 @@ resource "openstack_compute_volume_attach_v2" "data_volume" {
 ##### Floating IP association
 #####
 
-resource "openstack_compute_floatingip_associate_v2" "cluster_floatingip_assoc" {
+resource "openstack_networking_floatingip_associate_v2" "cluster_floatingip_assoc" {
   floating_ip = "{{ cluster_floating_ip_address }}"
-  instance_id = "${openstack_compute_instance_v2.cluster_server.id}"
+  port_id = "${openstack_networking_port_v2.cluster.id}"
 }
 {% endif %}


### PR DESCRIPTION
And for now, we have to pin at version 2.1.0,
because 3.0.0 drops support for the deprecated resource.

This fixed the error about an invalid resource type:

The provider terraform-provider-openstack/openstack does not support resource
type "openstack_compute_floatingip_associate_v2".