### PR TITLE
Add SSH connection retries to mitigate DNS lookup failures

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,3 +10,4 @@ roles_path = roles
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=240s -o PreferredAuthentications=publickey -o UserKnownHostsFile=/dev/null
 pipelining = True
+retries = 10


### PR DESCRIPTION
We've seen intermittent failures in workstation provisioning due to errors in the Ansible `wait_for_connection` module used within [azimuth-cloud/ansible-collection-terraform](https://github.com/azimuth-cloud/ansible-collection-terraform). These seem to be cause by a race condition involving Zenith k8s service FQDNs and manifest in warning such as:

```
"[WARNING]: Unhandled error in Python interpreter discovery for host localhost:\r\nFailed to connect to the host via ssh: ssh: Could not resolve hostname\r\n mf5eqa2rxvpqvi9d7cvazd4gwjr3lxz538lq.zenith-services.svc.cluster.local: Name or\r\nservice not known" ...
```

Adding SSH connection retries seems to mitigate this since FQDN resolution is retried for each new SSH connection attempt.