### PR TITLE
Revert "Add SSH connection retries to mitigate DNS lookup failures"

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -10,4 +10,3 @@ roles_path = roles
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=240s -o PreferredAuthentications=publickey -o UserKnownHostsFile=/dev/null
 pipelining = True
-retries = 10


### PR DESCRIPTION
Reverts azimuth-cloud/caas-workstation#32

Retries are now configured by the CaaS operator as part of [this change](https://github.com/azimuth-cloud/azimuth-caas-operator/pull/221) so no need to explicitly specify retries here.